### PR TITLE
Disable start2Activity if no new version and Latest version toast is disabled

### DIFF
--- a/lib/src/main/java/com/kcode/lib/UpdateWrapper.java
+++ b/lib/src/main/java/com/kcode/lib/UpdateWrapper.java
@@ -81,7 +81,9 @@ public class UpdateWrapper {
                 mCallback.callBack(model, hasNewVersion);
             }
 
-            start2Activity(mContext, model);
+            if (hasNewVersion || mIsShowToast) {
+                start2Activity(mContext, model);
+            }
         }
 
     };


### PR DESCRIPTION
There is no benefit of starting an Activity if there is no new version and if `setIsShowToast(false)`.