### PR TITLE
Fixed NullPointerException crashes

### DIFF
--- a/lib/src/main/java/com/kcode/lib/dialog/DownLoadDialog.java
+++ b/lib/src/main/java/com/kcode/lib/dialog/DownLoadDialog.java
@@ -213,22 +213,25 @@ public class DownLoadDialog extends DialogFragment implements View.OnClickListen
                                 Formatter.formatFileSize(getActivity().getApplication(), contentLength)));
                     break;
                 case DONE:
-                    getActivity().startActivity(FileUtils.openApkFile(getActivity(), new File(FileUtils.getApkFilePath(getActivity(), mDownloadUrl))));
-                    getActivity().finish();
-                    ToastUtils.show(getActivity(), R.string.update_lib_download_finish);
+                    if (getActivity() != null) {
+                        getActivity().startActivity(FileUtils.openApkFile(getActivity(), new File(FileUtils.getApkFilePath(getActivity(), mDownloadUrl))));
+                        getActivity().finish();
+                        ToastUtils.show(getActivity(), R.string.update_lib_download_finish);
+                    }
                     break;
                 case ERROR:
-                    ToastUtils.show(getActivity(), R.string.update_lib_download_failed);
+                    if (getActivity() != null)
+                        ToastUtils.show(getActivity(), R.string.update_lib_download_failed);
                     if (!mMustUpdate) {
                         dismiss();
-                        getActivity().finish();
+                        if (getActivity() != null)
+                            getActivity().finish();
                     } else {
                         dismiss();
                         if (mOnFragmentOperation != null) {
                             mOnFragmentOperation.onFailed();
                         }
                     }
-
                     break;
             }
         }


### PR DESCRIPTION
Fixed `NullPointerException` crashes, please test first to make sure this doesn't cause any other issues.

```
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'void android.app.Activity.finish()' on a null object reference
```

``` 
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'java.io.File android.content.Context.getExternalFilesDir(java.lang.String)' on a null object reference
```